### PR TITLE
Add Rails4.2 and Rails5.1 support  and travis-ci tests settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: ruby
+sudo: false
+cache: bundler
+
+rvm:
+  - 2.2.3
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+
+gemfile:
+  - Gemfile
+  - gemfiles/rails4_2.gemfile
+  - gemfiles/rails5_1.gemfile
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+
+
+script: bundle exec cucumber

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem "rails"
 # Specify your gem's dependencies in bitcoin_payable.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BitcoinPayable
 
+[![Build Status](https://travis-ci.org/starcharles/bitcoin_payable.svg?branch=master)](https://travis-ci.org/starcharles/bitcoin_payable)
+
 A rails gem that enables any model to have bitcoin payments.
 The polymorphic table bitcoin_payments creates payments with unique addresses based on a BIP32 deterministic seed using https://github.com/wink/money-tree
 and uses the (https://helloblock.io OR https://blockchain.info/) API to check for payments.

--- a/bitcoin_payable.gemspec
+++ b/bitcoin_payable.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cucumber-rails"
   spec.add_dependency "rspec-rails"
   spec.add_dependency "database_cleaner"
-  spec.add_dependency "state_machine"
+  spec.add_dependency "state_machines"
+  spec.add_dependency "state_machines-activerecord"
   spec.add_dependency "blockcypher-ruby"
   spec.add_dependency "money-tree"
 end

--- a/bitcoin_payable.gemspec
+++ b/bitcoin_payable.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = '>= 1.3.6'
 
-  spec.add_dependency "rails"
   spec.add_dependency "cucumber-rails"
   spec.add_dependency "rspec-rails"
   spec.add_dependency "database_cleaner"

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec path: '../'
+gem 'rails', '~> 4.2.8'

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gemspec path: '../'
+gem 'rails', '~> 5.1.4'

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -1,6 +1,7 @@
 #require 'bitcoin-addrgen'
 require 'money-tree'
-require 'state_machine'
+require 'state_machines'
+require 'state_machines-activerecord'
 
 module BitcoinPayable
   class BitcoinPayment < ::ActiveRecord::Base

--- a/lib/bitcoin_payable/config.rb
+++ b/lib/bitcoin_payable/config.rb
@@ -12,5 +12,9 @@ module BitcoinPayable
     def network
       @testnet == false ? :bitcoin : :bitcoin_testnet
     end
+
+    def adapter
+      @adapter ||= "blockchain_info"
+    end
   end
 end

--- a/spec/dummy/config/initializers/state_machine.rb
+++ b/spec/dummy/config/initializers/state_machine.rb
@@ -1,3 +1,0 @@
-module StateMachine::Integrations::ActiveModel
-   public :around_validation
-end


### PR DESCRIPTION
This PR is mainly for issue #21 . Activerecord related bug in state_machine is annoyed me.

So
- changed long time unmaintained library, 'state_machine' to 'state_machines' libraries
- added .travis.yml to test in multiple ruby versions and Rails versions
- tests denoted the compatiblity for either rails 4.2, and 5.1( I didn't test Rails 3.)


If any misunderstang, please tell me for rather improvement.

Thanks