### PR TITLE
Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,42 @@ Or install it yourself as:
 
 config/initializers/bitcoin_payable.rb
 
-    BitcoinPayable.config.currency = :cad
-    BitcoinPayable.config.node_path = "m/0/"
-    BitcoinPayable.config.master_public_key = ENV["MASTER_PUBLIC_KEY"]
-    BitcoinPayable.config.testnet = true
-    BitcoinPayable.config.adapter = "blockchain_info"
+  BitcoinPayable.config do |config|
+
+    config.currency = :usd    # Default currency
+
+    # Webhooks
+    # Only available for blocktrail adapter
+    config.allowwebhooks = true
+    config.auto_calculate_rate_every = 5.hours # Only when webhooks are enabled
+    config.webhook_domain = "domain.com"       # No subdomains or IPs supported
+    config.webhook_port = "3000"               # Let empty if it's not needed
+
+    config.node_path = "m/0/"
+    config.master_public_key = "your xpub master public key here"
+
+    config.testnet = true
+    config.adapter = 'blocktrail' # Use blocktrail, blockchain_info or blockcypher
+  end
 
 
 * In order to use the bitcoin network and issue real addresses, BitcoinPayable.config.testnet must be set to false *
 
     BitcoinPayable.config.testnet = false
 
+#### Blocktrail Adapter
+
+If you use `config.adapter = 'blocktrail'` * The only one supporting webhooks* you'll need to set the following environment variables:
+
+    # Basic authentification for your webhooks
+    ENV['BITCOINPAYABLE_WEBHOOK_NAME']= "key"
+    ENV['BITCOINPAYABLE_WEBHOOK_PASS']= "key"
+
+    # API keys provided by Blocktrail.com
+    ENV['BLOCKTRAIL_API_KEY']= "key"
+    ENV['BLOCKTRAIL_API_SECRET']= "secret"
+
+You can obtain your API keys at https://www.blocktrail.com/dev/login
 #### Node Path
 
 The derivation path for the node that will be creating your addresses

--- a/app/controllers/bitcoin_payable/bitcoin_payment_transaction_controller.rb
+++ b/app/controllers/bitcoin_payable/bitcoin_payment_transaction_controller.rb
@@ -1,0 +1,39 @@
+require 'bitcoin_payable/commands/payment_processor'
+
+module BitcoinPayable
+  class BitcoinPaymentTransactionController < ActionController::Base
+    http_basic_authenticate_with name: ENV['BITCOINPAYABLE_WEBHOOK_NAME'],
+                                 password: ENV['BITCOINPAYABLE_WEBHOOK_PASS']
+
+    # POST bitcoin/notifytransaction
+    def notify_transaction
+      adapter = BitcoinPayable::Adapters::Base.fetch_adapter
+      address = adapter.extract_address_from_incoming_tx(params)
+
+      incoming_tx = BitcoinPaymentTransaction.format_transaction(params,address)
+
+      payment = BitcoinPayment.where(address: address).last!
+      unless payment.transactions.find_by_transaction_hash(incoming_tx[:transaction_hash]).nil?
+        render plain: '', template:false, status: :not_found
+        return
+      end
+
+      payment.transactions.create!(incoming_tx)
+      payment.update_after_new_transactions    # Not secure but will be monitored
+      render plain: 'ok', template:false, status: :ok
+    end
+
+    # POST last_block
+    def last_block
+      PaymentProcessor.perform
+      last_rate_cheked = CurrencyConversion.pluck(:updated_at).last
+      if last_rate_cheked < BitcoinPayable.config.auto_calculate_rate_every.ago
+        PricingProcessor.perform
+      end
+
+      render plain: 'ok', template:false, status: :ok
+    end
+
+    private
+  end
+end

--- a/bitcoin_payable.gemspec
+++ b/bitcoin_payable.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "state_machine"
   spec.add_dependency "blockcypher-ruby"
   spec.add_dependency "money-tree"
+  spec.add_dependency "blocktrail"
 end

--- a/bitcoin_payable.gemspec
+++ b/bitcoin_payable.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cucumber-rails"
   spec.add_dependency "rspec-rails"
   spec.add_dependency "database_cleaner"
-  spec.add_dependency "state_machine"
+  spec.add_dependency "aasm"
   spec.add_dependency "blockcypher-ruby"
   spec.add_dependency "money-tree"
   spec.add_dependency "blocktrail"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,6 @@
+Rails.application.routes.draw do
+    if BitcoinPayable.config.allowwebhooks
+      post 'bitcoin/notifytransaction', to: 'bitcoin_payable/bitcoin_payment_transaction#notify_transaction'
+      post 'bitcoin/lastblock', to: 'bitcoin_payable/bitcoin_payment_transaction#last_block'
+    end
+end

--- a/lib/bitcoin_payable.rb
+++ b/lib/bitcoin_payable.rb
@@ -5,10 +5,8 @@ require 'bitcoin_payable/has_bitcoin_payment'
 require 'bitcoin_payable/tasks'
 require 'bitcoin_payable/bitcoin_calculator'
 
-require 'blockcypher'
 require 'bitcoin_payable/adapters/base'
-require 'bitcoin_payable/adapters/blockcypher_adapter'
-require 'bitcoin_payable/adapters/blockchain_info_adapter'
+require 'bitcoin_payable/engine'
 
 module BitcoinPayable
   def self.config(&block)

--- a/lib/bitcoin_payable.rb
+++ b/lib/bitcoin_payable.rb
@@ -11,8 +11,9 @@ require 'bitcoin_payable/adapters/blockcypher_adapter'
 require 'bitcoin_payable/adapters/blockchain_info_adapter'
 
 module BitcoinPayable
-  def self.config
+  def self.config(&block)
     @@config ||= BitcoinPayable::Config.instance
+    block_given? ? block.call(@@config) : @@config
   end
 end
 

--- a/lib/bitcoin_payable/adapters/base.rb
+++ b/lib/bitcoin_payable/adapters/base.rb
@@ -1,14 +1,42 @@
 module BitcoinPayable::Adapters
   class Base
+    def initialize
+      if BitcoinPayable.config.allowwebhooks
+        configure_webhooks
+        subscribe_notification_each_block
+      end
+    end
 
-    def self.fetch_adapter
-      case BitcoinPayable.config.adapter
-      when "blockchain_info"
-        BitcoinPayable::Adapters::BlockchainInfoAdapter.new
-      when "blockcypher"
-        BitcoinPayable::Adapters::BlockcypherAdapter.new
-      else
-        raise "Please specify an adapter"
+    def configure_webhooks
+    end
+
+    def subscribe_notification_each_block
+    end
+
+    def desubscribe_tx_notifications
+      raise "Adapter #{self} doesn't support notifications on transactions"
+    end
+
+    def subscribe_tx_notifications
+      raise "Adapter #{self} doesn't support notifications on transactions"
+    end
+
+    class << self
+      def fetch_adapter
+        unless BitcoinPayable.config.adapter.blank?
+          load_adapters
+          api = BitcoinPayable.config.adapter
+          adapter_class = api.camelize + 'Adapter'
+          adapter_class = BitcoinPayable::Adapters.const_get(adapter_class)
+          adapter = adapter_class.new
+        else
+          raise "Please specify an adapter"
+        end
+      end
+      def load_adapters
+        lib_dir = File.dirname(__FILE__)
+        full_pattern = File.join(lib_dir, '*_adapter.rb')
+        Dir.glob(full_pattern).each {|file| require file}
       end
     end
 

--- a/lib/bitcoin_payable/adapters/blockchain_info_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blockchain_info_adapter.rb
@@ -1,12 +1,13 @@
 module BitcoinPayable::Adapters
-  class BlockchainInfoAdapter
+  class BlockchainInfoAdapter < Base
 
     def initialize
       if BitcoinPayable.config.testnet
-        raise "Testnet not supported" 
+        raise "Testnet not supported"
       else
         @url = "https://blockchain.info"
       end
+      super
     end
 
     def fetch_transactions_for_address(address)
@@ -16,7 +17,7 @@ module BitcoinPayable::Adapters
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      
+
       request = Net::HTTP::Get.new(uri.request_uri)
       response = http.request(request)
 

--- a/lib/bitcoin_payable/adapters/blockcypher_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blockcypher_adapter.rb
@@ -1,6 +1,6 @@
 require 'blockcypher'
 module BitcoinPayable::Adapters
-  class BlockcypherAdapter
+  class BlockcypherAdapter < Base
 
     def initialize
       if BitcoinPayable.config.testnet
@@ -8,6 +8,7 @@ module BitcoinPayable::Adapters
       else
         @blockcypher = BlockCypher::Api.new
       end
+      super
     end
 
     def fetch_transactions_for_address(address)

--- a/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
@@ -1,0 +1,101 @@
+require 'blocktrail'
+module BitcoinPayable::Adapters
+  class BlocktrailAdapter < Base
+    @@each_block_subscribed = false
+
+    def initialize
+      if BitcoinPayable.config.testnet
+        @client ||= Blocktrail::Client.new(testnet: true)
+      else
+        @client ||= Blocktrail::Client.new
+      end
+      super
+    end
+
+    def fetch_transactions_for_address(address)
+      begin
+        hash = @client.address_transactions(address)
+        return if hash['data'].nil?
+        hash['data'].map{|tx| convert_transactions(tx, address)}
+      rescue Blocktrail::Exceptions::ObjectNotFound => e
+        puts "Address #{address} not found:#{e}"
+        return nil
+      end
+    end
+
+    def convert_transactions(transaction, address)
+      transaction = transaction[:data] if transaction.has_key?(:data)
+      {
+        #confirmations:      transaction['confirmations'],
+        transaction_hash:   transaction['hash'],
+        block_hash:         transaction['block_hash'],
+        #block_number:       transaction['block_height'],
+        block_time:         (Time.at(transaction['block_time']) if transaction['block_time']),  # Not supported
+        estimated_time:     (Time.at(transaction[:estimated_time]) if transaction[:estimated_time]),
+        estimated_value:    transaction['outputs'].sum do |outs|
+                              outs['address'] == address ? outs['value'] : 0
+                            end
+      }
+    end
+
+    def subscribe_tx_notifications(address)
+      @client.subscribe_address_transactions(@new_tx_webhook_id, address, 0)
+    end
+
+    def desubscribe_tx_notifications(address)
+      begin
+        @client.unsubscribe_address_transactions(@new_tx_webhook_id,address)
+      rescue Blocktrail::Exceptions::ObjectNotFound => e
+        puts "Address #{address} not found:#{e}"
+      end
+    end
+
+    def extract_address_from_incoming_tx(params)
+      raise "Incorrect request" unless params[:event_type] == "address-transactions"
+      address = params[:addresses].keys.last
+    end
+
+    private
+    def subscribe_notification_each_block
+      return if @@each_block_subscribed
+      begin
+        @client.subscribe_new_blocks(@new_block_webhook_id)
+        @@each_block_subscribed = true
+      rescue Blocktrail::Exceptions::ObjectNotFound => e
+        puts "Error when subscribint to notification for each block: #{e}"
+        @@each_block_subscribed = false
+      rescue Blocktrail::Exceptions::EndpointSpecificError => e
+        puts "Notification for each block seems already subscribed: #{e}"
+        @@each_block_subscribed = true
+      end
+    end
+
+    def configure_webhooks
+      @new_tx_webhook_id = Rails.application.class.parent_name
+      @new_tx_webhook_url = webhook_url_for(:notify_transaction)
+      setup_webhook(@new_tx_webhook_id, @new_tx_webhook_url)
+
+      @new_block_webhook_id = Rails.application.class.parent_name + "-new-block"
+      @new_block_webhook_url = webhook_url_for(:last_block)
+      setup_webhook(@new_block_webhook_id, @new_block_webhook_url)
+    end
+
+    def setup_webhook(webhook_id, url)
+      if @client.all_webhooks['data'].any?{|webhook| webhook["identifier"] == webhook_id}
+        @client.update_webhook webhook_id, url
+      else
+        @client.setup_webhook url, webhook_id
+      end
+    end
+
+    def webhook_url_for(action)
+      Rails.application.routes.url_for(
+                                :user => ENV['BITCOINPAYABLE_WEBHOOK_NAME'],
+                                :password => ENV['BITCOINPAYABLE_WEBHOOK_PASS'],
+                                :controller => "bitcoin_payable/bitcoin_payment_transaction",
+                                :action => "#{action.to_s}",
+                                :host => BitcoinPayable.config.webhook_domain,
+                                :port => BitcoinPayable.config.webhook_port)
+    end
+  end
+end

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -1,10 +1,10 @@
 #require 'bitcoin-addrgen'
 require 'money-tree'
-require 'state_machine'
+require 'aasm'
 
 module BitcoinPayable
   class BitcoinPayment < ::ActiveRecord::Base
-
+    include AASM
     belongs_to :payable, polymorphic: true
     has_many :transactions, class_name: "BitcoinPayable::BitcoinPaymentTransaction"
 
@@ -15,28 +15,30 @@ module BitcoinPayable
     after_create :populate_address
     after_create :subscribe_tx_notifications, if: :webhooks_enabled
 
-    state_machine :state, initial: :pending do
-      state :pending
-      state :partial_payment
-      state :paid_in_full
-      state :comped
+    aasm :column => 'state' do
+      state :pending, :initial => true
+      state :partial_payment, :paid_in_full, :comped
 
       event :paid do
-        transition [:pending, :partial_payment] => :paid_in_full
+        after do
+          notify_payable
+          desubscribe_tx_notifications
+        end
+        transitions :from => [:pending, :partial_payment], :to => :paid_in_full
       end
 
-      after_transition :on => :paid, :do => :notify_payable
-      after_transition :on => :paid, :do => :desubscribe_tx_notifications if BitcoinPayable.config.allowwebhooks
-
       event :partially_paid do
-        transition :pending => :partial_payment
+        transitions :from => :pending, :to => :partial_payment
       end
 
       event :comp do
-        transition [:pending, :partial_payment] => :comped
+        after do
+          notify_payable
+        end
+        transitions :from => [:pending, :partial_payment], :to => :comped
       end
 
-      after_transition :on => :comp, :do => :notify_payable
+
     end
 
     def currency_amount_paid
@@ -62,11 +64,9 @@ module BitcoinPayable
     def check_if_paid
       fiat_paid = currency_amount_paid
       if fiat_paid >= price
-        paid
+        paid!
       elsif fiat_paid > 0
-        partially_paid
-      else
-        nothing_paid
+        partially_paid!
       end
     end
 

--- a/lib/bitcoin_payable/bitcoin_payment_transaction.rb
+++ b/lib/bitcoin_payable/bitcoin_payment_transaction.rb
@@ -3,5 +3,16 @@ module BitcoinPayable
 
     belongs_to :bitcoin_payment
 
+    before_save :add_conversion
+
+    def self.format_transaction(transaction, recepient_address)
+      adapter = BitcoinPayable::Adapters::Base.fetch_adapter
+      adapter.convert_transactions(transaction, recepient_address)
+    end
+
+    def add_conversion
+      adapter = BitcoinPayable::Adapters::Base.fetch_adapter
+      self.btc_conversion ||= bitcoin_payment.btc_conversion
+    end
   end
 end

--- a/lib/bitcoin_payable/commands/payment_processor.rb
+++ b/lib/bitcoin_payable/commands/payment_processor.rb
@@ -9,17 +9,13 @@ module BitcoinPayable
 
     def perform
       BitcoinPayable::BitcoinPayment.where(state: [:pending, :partial_payment]).each do |payment|
-        # => Check for completed payment first, incase it's 0 and we don't need to make an API call
-        # => Preserve API calls
-        check_paid(payment)
-
         unless payment.paid_in_full?
           begin
             adapter = BitcoinPayable::Adapters::Base.fetch_adapter
 
             adapter.fetch_transactions_for_address(payment.address).each do |tx|
+              next if tx.nil?
               tx.symbolize_keys!
-
               unless payment.transactions.find_by_transaction_hash(tx[:txHash])
                 payment.transactions.create!(
                   estimated_value: tx[:estimatedTxValue],
@@ -30,18 +26,14 @@ module BitcoinPayable
                   btc_conversion: payment.btc_conversion
                 )
 
-                payment.update(btc_amount_due: payment.calculate_btc_amount_due, btc_conversion: BitcoinPayable::CurrencyConversion.last.btc)
+                payment.update_after_new_transactions
               end
             end
-
-            # => Check for payments after the response comes back
-            check_paid(payment)
-
           rescue JSON::ParserError
             puts "Error processing response from server.  Possible API issue or your Quota has been exceeded"
           end
         end
-        
+
       end
     end
 

--- a/lib/bitcoin_payable/commands/payment_processor.rb
+++ b/lib/bitcoin_payable/commands/payment_processor.rb
@@ -37,16 +37,6 @@ module BitcoinPayable
       end
     end
 
-    protected
-
-    def check_paid(payment)
-      if payment.currency_amount_paid >= payment.price
-        payment.paid
-      elsif payment.currency_amount_paid > 0
-         payment.partially_paid
-      end
-    end
-
   end
 
 end

--- a/lib/bitcoin_payable/config.rb
+++ b/lib/bitcoin_payable/config.rb
@@ -3,7 +3,9 @@ require 'singleton'
 module BitcoinPayable
   class Config
     include Singleton
-    attr_accessor :master_public_key, :node_path, :currency, :open_exchange_key, :testnet, :adapter, :adapter_api_key
+    attr_accessor :master_public_key, :node_path, :currency, :open_exchange_key,
+                  :testnet, :adapter, :adapter_api_key, :allowwebhooks, :webhook_domain,
+                  :webhook_port, :auto_calculate_rate_every
 
     def initialize
       @currency ||= :cad

--- a/lib/bitcoin_payable/engine.rb
+++ b/lib/bitcoin_payable/engine.rb
@@ -1,0 +1,3 @@
+module BitcoinPayable
+  class Engine < Rails::Engine; end
+end

--- a/lib/generators/bitcoin_payable/install_generator.rb
+++ b/lib/generators/bitcoin_payable/install_generator.rb
@@ -10,14 +10,25 @@ module BitcoinPayable
     desc 'Generates (but does not run) a migration to add a bitcoin payment tables.'
 
     def create_migration_file
-      migration_template 'create_bitcoin_payments.rb', 'db/migrate/create_bitcoin_payments.rb'
-      migration_template 'create_bitcoin_payment_transactions.rb', 'db/migrate/create_bitcoin_payment_transactions.rb'
-      migration_template 'create_currency_conversions.rb', 'db/migrate/create_currency_conversions.rb'
-      migration_template 'add_btc_conversion_to_bitcoin_payments.rb', 'db/migrate/add_btc_conversion_to_bitcoin_payments.rb'
+      migration_template 'create_bitcoin_payments.rb', 'db/migrate/create_bitcoin_payments.rb', migration_version: migration_version
+      migration_template 'create_bitcoin_payment_transactions.rb', 'db/migrate/create_bitcoin_payment_transactions.rb', migration_version: migration_version
+      migration_template 'create_currency_conversions.rb', 'db/migrate/create_currency_conversions.rb', migration_version: migration_version
+      migration_template 'add_btc_conversion_to_bitcoin_payments.rb', 'db/migrate/add_btc_conversion_to_bitcoin_payments.rb', migration_version: migration_version
     end
 
     def self.next_migration_number(dirname)
       ::ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
+
+    def rails5?
+      Rails.version.start_with? '5'
+    end
+
+    def migration_version
+      if rails5?
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+      end
+    end
+
   end
 end

--- a/lib/generators/bitcoin_payable/templates/add_btc_conversion_to_bitcoin_payments.rb
+++ b/lib/generators/bitcoin_payable/templates/add_btc_conversion_to_bitcoin_payments.rb
@@ -1,4 +1,4 @@
-class AddBtcConversionToBitcoinPayments < ActiveRecord::Migration
+class AddBtcConversionToBitcoinPayments < ActiveRecord::Migration<%= migration_version %>
   def change
     add_column :bitcoin_payments, :btc_conversion, :integer
   end

--- a/lib/generators/bitcoin_payable/templates/create_bitcoin_payment_transactions.rb
+++ b/lib/generators/bitcoin_payable/templates/create_bitcoin_payment_transactions.rb
@@ -1,4 +1,4 @@
-class CreateBitcoinPaymentTransactions < ActiveRecord::Migration
+class CreateBitcoinPaymentTransactions < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :bitcoin_payment_transactions do |t|
       t.integer :estimated_value

--- a/lib/generators/bitcoin_payable/templates/create_bitcoin_payments.rb
+++ b/lib/generators/bitcoin_payable/templates/create_bitcoin_payments.rb
@@ -1,4 +1,4 @@
-class CreateBitcoinPayments < ActiveRecord::Migration
+class CreateBitcoinPayments < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :bitcoin_payments do |t|
       t.string   :payable_type

--- a/lib/generators/bitcoin_payable/templates/create_currency_conversions.rb
+++ b/lib/generators/bitcoin_payable/templates/create_currency_conversions.rb
@@ -1,4 +1,4 @@
-class CreateCurrencyConversions < ActiveRecord::Migration
+class CreateCurrencyConversions < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :currency_conversions do |t|
       t.float "currency"


### PR DESCRIPTION
This is the first chunk of the big and maybe not very clear PR https://github.com/Sailias/bitcoin_payable/pull/30

I've been trying to strip out the PR https://github.com/Sailias/bitcoin_payable/pull/30 so the three features can branch off master but I've been feeling very miserable trying as this PR is a 'dependency' for the following ones. 
There are many reasons for this, as for example the only Adapter supporting Bitcoin Cash is the adapter included in this PR and also I did some changes to improve the code such as inheriting `BitcoinPayable::Adapters::Base` from the adapters to implement a Template pattern (mainly to open up the door for webhooks). 
In addition I did also move some logic out of [lib/bitcoin_payable/commands/payment_processor.rb](https://github.com/Sailias/bitcoin_payable/compare/master...maesitos:webhooks?expand=1#diff-5935743f69a5a3224f23873fdee5faf9) and delegated it into the BitcoinPayment class:

```
payment.update(btc_amount_due: payment.calculate_btc_amount_due, btc_conversion: BitcoinPayable::CurrencyConversion.last.btc) 
```
and

```
def check_paid(payment)
    if payment.currency_amount_paid >= payment.price
      payment.paid
    elsif payment.currency_amount_paid > 0
        payment.partially_paid
      end
 end
```

The above code should actually be part of the BitcoinPayment class and was making [lib/bitcoin_payable/commands/payment_processor.rb](https://github.com/Sailias/bitcoin_payable/compare/master...maesitos:webhooks?expand=1#diff-5935743f69a5a3224f23873fdee5faf9) hard to read. This became even more clear once I started to add security for transactions and confirmations (not included in this PR).

Maybe some of the changes here could had been posted in a different PRs but since this PR is already small I thought it was a good place.

If you like these changes I'll request two more PR on top of the merged changes. Maybe this time I'll be able to do two separate PR. You may want to merge it into Develop branch and finally merge it into master once we are done.

## Webhooks

Enable them by setting BitcoinPayable.config.allowwebhooks = true. The gem will set two routes:

### `bitcoin/lastblock`

Will be called every block and will trigger rake bitcoin_payable:process_payments to see if the pending payments have been paid or to monitor the transaction that are still not secure.

### `bitcoin/notifytransaction`

This route will receive and store transactions. This will give the user the experience of sending an instant payment. Take into consideration this is taking any transaction as valid, without considering its security based on the number of confirmations.

## Replacing state-machine with AASM

**state-machine** is deprecated and was not triggering the after_transition methods in Rails 5.1. Additionally a default value should be set for the 'state' column of the database in order to eliminate a bug in the code. Basically state-machine is very buggy and the maintained repo is now called **state_machines-activerecord** but doesn't support Rails 3 so I preferred to use AASM as its interface is very similar and has backwards compatibility with Rails.


## Fixing migrations templates for rails 5.1
The commit is self explanatory and essentially the templates weren't working with Rails 5.1