### PR TITLE
[Bug fix] verify all transactions associated with a payment before setting it to :confirmed

### DIFF
--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -60,6 +60,11 @@ module BitcoinPayable
       BitcoinPayable::BitcoinCalculator.exchange_price currency_amount_due, btc_rate
     end
 
+    def secure?
+      return true if transactions.all?{|tx| tx.secure?}
+      return false
+    end
+
     private
 
     def populate_currency_and_amount_due

--- a/lib/bitcoin_payable/bitcoin_payment_transaction.rb
+++ b/lib/bitcoin_payable/bitcoin_payment_transaction.rb
@@ -9,5 +9,10 @@ module BitcoinPayable
       adapter = BitcoinPayable::Adapters::Base.fetch_adapter
       self.btc_conversion ||= bitcoin_payment.btc_conversion
     end
+
+    def secure?
+      return true if self.confirmations >= BitcoinPayable.config.confirmations 
+      return false
+    end
   end
 end

--- a/lib/bitcoin_payable/interactors/transaction_processor/determine_payment_status.rb
+++ b/lib/bitcoin_payable/interactors/transaction_processor/determine_payment_status.rb
@@ -4,7 +4,7 @@ module BitcoinPayable::Interactors::TransactionProcessor
 
     def call
       fiat_paid = context.bitcoin_payment.currency_amount_paid
-      
+
       if fiat_paid >= context.bitcoin_payment.price
         handle_paid_in_full unless context.bitcoin_payment.confirmed?
       elsif fiat_paid > 0
@@ -15,19 +15,19 @@ module BitcoinPayable::Interactors::TransactionProcessor
     private
 
     def handle_paid_in_full
-      if context.bitcoin_payment_transaction.confirmations >= BitcoinPayable.config.confirmations
+      if context.bitcoin_payment.secure?
         # This payment is already paid in full, we should check the confirmation count
         context.bitcoin_payment.confirm!
 
       elsif !context.bitcoin_payment.paid_in_full?
         # This payment has not been marked as paid yet, let's mark it
-        context.bitcoin_payment.paid! 
+        context.bitcoin_payment.paid!
       end
     end
 
     def handle_partial_paid
       unless context.bitcoin_payment.partial_payment?
-        context.bitcoin_payment.partially_paid! 
+        context.bitcoin_payment.partially_paid!
       end
     end
 


### PR DESCRIPTION
I created a modification discussed at https://github.com/Sailias/bitcoin_payable/issues/40