### PR TITLE
Multifiat, Bitcoin Cash support and some bugs fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BitcoinPayable
 
+Support Bitcoin and Bitcoin Cash in your Ruby on Rails application!
+
 A rails gem that enables any model to have bitcoin payments.
 The polymorphic table bitcoin_payments creates payments with unique addresses based on a BIP32 deterministic seed using https://github.com/wink/money-tree
 and uses the (https://helloblock.io OR https://blockchain.info/) API to check for payments.
@@ -13,6 +15,7 @@ Support for multiple fiat currencies: `USD` `EUR` `GBP` `AUD` `BRL` `CAD` `CZK` 
 Donations appreciated
 
 `142WJW4Zzc9iV7uFdbei8Unpe8WcLhUgmE`
+`bitcoincash:qqsnzsxsytmp45t6ndyaz5etj0x9vvacvqmphswqa8`
 
 ## Rails 5.1
 
@@ -53,6 +56,10 @@ Or install it yourself as:
 BitcoinPayable.config do |config|
 
   config.currency = :usd    # Default currency
+
+  # Bitcoin or Bitcoin Bitcoin Cash
+  # Blockcypher and Blockchain.info still to add BCH support
+  config.crypto = :btc # or :bch   
 
   config.node_path = "m/0/"
   config.master_public_key = "your xpub master public key here"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ end
 
 #### Blocktrail Adapter
 
-If you use `config.adapter = 'blocktrail'` * The only one supporting webhooks* you'll need to set the following environment variables:
+If you use `config.adapter = 'blocktrail'` *(The only one supporting webhooks)* you'll need to set the following environment variables:
 
     # Basic authentification for your webhooks
     ENV['BITCOIN_PAYABLE_WEBHOOK_USER']= "username"
@@ -103,7 +103,9 @@ If you use `config.adapter = 'blocktrail'` * The only one supporting webhooks* y
     ENV['BLOCKTRAIL_API_KEY']= "key"
     ENV['BLOCKTRAIL_API_SECRET']= "secret"
 
-You can obtain your API keys at https://www.blocktrail.com/dev/login
+Please bear in mind [Blocktrail.com](http://blocktrail.com) was acquired by [Bitmain](http://bitmain.com) and the service has ben entirely moved to [BTC.com](http://btc.com).
+
+You can obtain your API keys at https://dev.btc.com
 
 #### Node Path
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Payments have 5 states:  `pending`, `partial_payment`, `paid_in_full`, `confirme
 
 No private keys needed, No bitcoind blockchain indexing on new servers, just address and payments.
 
+Support for multiple fiat currencies: `USD` `EUR` `GBP` `AUD` `BRL` `CAD` `CZK` `IDR` `ILS` `JPY` `MXN` `MYR` `NZD` `PLN` `RUB` `SEK` `SGD` `TRY`
+
 Donations appreciated
 
 `142WJW4Zzc9iV7uFdbei8Unpe8WcLhUgmE`
@@ -60,6 +62,7 @@ BitcoinPayable.config do |config|
 
   # Confirmations (defaults to 6)
   config.confirmations = 6
+<<<<<<< HEAD
 
   # The rate for Bitcoin you'll be using to calculate prices
   # Optional setting. Default to :daily_average
@@ -70,6 +73,8 @@ BitcoinPayable.config do |config|
   # :weekly_average     The weekly average price
   # :monthly_average    The monthly average price
   config.rate_calculation = :daily_average
+=======
+>>>>>>> readme changes
 
   # Webhooks
   # Only available for blocktrail adapter
@@ -116,18 +121,27 @@ Testnet starts with: tpub
 ### Creating a payment from your application
 
     def create_payment(amount_in_cents)
-      self.bitcoin_payments.create!(reason: 'sale', price: amount_in_cents)
+      self.bitcoin_payments.create!(reason: 'sale', price: amount_in_cents, currency: :eur)
     end
+
+If `currency` is not provided the default fiat currency will be used. You can create a Bitcoin payment for a new—supported—fiat currency and BitcoinPayable will automatically create obtain the exchange rate before creating the payment.
 
 ### Update payments with the current price of BTC based on your currency
 
-BitcoinPayable also supports local currency conversions and BTC exchange rates.
+BitcoinPayable also supports multiple fiat currencies conversions and BTC exchange rates.
 
 The `process_prices` rake task connects to api.bitcoinaverage.com to get the 24 hour weighted average of BTC for your specified currency.
-It then updates all payments that havent received an update in the last 30 minutes with the new value owing in BTC.
+It then updates all payments that haven't received an update in the last 30 minutes with the new value owing in BTC.
 This *honors* the price of a payment for 30 minutes at a time.
 
 `rake bitcoin_payable:process_prices`
+
+BitcoinPayable will update the prices for all the fiat pairs.
+
+#### Clean up old rates
+You will be able to clean up old rates with:
+
+`rake bitcoin_payable:clean_old_rates` or `rake bitcoin_payable:clean_old_rates[days_old]`
 
 ### Processing payments
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ BitcoinPayable.config do |config|
 
   # Confirmations (defaults to 6)
   config.confirmations = 6
-<<<<<<< HEAD
 
   # The rate for Bitcoin you'll be using to calculate prices
   # Optional setting. Default to :daily_average
@@ -80,8 +79,6 @@ BitcoinPayable.config do |config|
   # :weekly_average     The weekly average price
   # :monthly_average    The monthly average price
   config.rate_calculation = :daily_average
-=======
->>>>>>> readme changes
 
   # Webhooks
   # Only available for blocktrail adapter

--- a/lib/bitcoin_payable/adapters/blockchain_info_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blockchain_info_adapter.rb
@@ -1,6 +1,8 @@
 module BitcoinPayable::Adapters
   class BlockchainInfoAdapter < Base
 
+    # TODO: Support Bitcoin Cash when it's ready at Blockcypher
+    
     def initialize
       if BitcoinPayable.config.testnet
         raise "Testnet not supported"

--- a/lib/bitcoin_payable/adapters/blockcypher_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blockcypher_adapter.rb
@@ -2,6 +2,7 @@ require 'blockcypher'
 module BitcoinPayable::Adapters
   class BlockcypherAdapter < Base
 
+    # TODO: Support Bitcoin Cash when it's ready at Blockcypher
     def initialize
       if BitcoinPayable.config.testnet
         @blockcypher = BlockCypher::Api.new(network: BlockCypher::TEST_NET_3)

--- a/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
@@ -75,7 +75,8 @@ module BitcoinPayable::Adapters
         controller: "bitcoin_payable/bitcoin_payment_transaction",
         action: "notify_transaction",
         bitcoin_payment_id: payment.id,
-        host: BitcoinPayable.config.webhook_domain
+        host: BitcoinPayable.config.webhook_domain,
+        protocol: BitcoinPayable.config.webhook_protocol.presence || 'http'
       )
     end
 

--- a/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
@@ -4,10 +4,12 @@ module BitcoinPayable::Adapters
   class BlocktrailAdapter < Base
 
     def initialize
+      coin = :bcc if BitcoinPayable.config.crypto == :bch # Blocktrail uses BCC tciker
+
       if BitcoinPayable.config.testnet
-        @client ||= Blocktrail::Client.new(testnet: true)
+        @client ||= Blocktrail::Client.new(testnet: true, coin: coin.to_s)
       else
-        @client ||= Blocktrail::Client.new
+        @client ||= Blocktrail::Client.new(coin: coin.to_s)
       end
       super
     end

--- a/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
@@ -51,11 +51,17 @@ module BitcoinPayable::Adapters
       )
     end
 
-    # Unsubscribe from the Blocktrail subscription for this address
+    # # Unsubscribe from the Blocktrail subscription for this address
+    # def unsubscribe_to_address_push_notifications(payment)
+    #   @client.unsubscribe_address_transactions(payment.id.to_s, payment.address)
+    # rescue Blocktrail::Exceptions::ObjectNotFound => e
+    #   puts "Blocktrail subscription for address #{address} not found: #{e}"
+    # end
+
     def unsubscribe_to_address_push_notifications(payment)
-      @client.unsubscribe_address_transactions(payment.id.to_s, payment.address)
-    rescue Blocktrail::Exceptions::ObjectNotFound => e
-      puts "Blocktrail subscription for address #{address} not found: #{e}"
+        @client.delete_webhook(payment.id)
+      rescue Blocktrail::Exceptions::EndpointSpecificError => e
+        puts "Blocktrail webhook '#{payment.id}' not found: #{e}"
     end
 
     private

--- a/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
+++ b/lib/bitcoin_payable/adapters/blocktrail_adapter.rb
@@ -2,7 +2,7 @@ require 'blocktrail'
 
 module BitcoinPayable::Adapters
   class BlocktrailAdapter < Base
-    
+
     def initialize
       if BitcoinPayable.config.testnet
         @client ||= Blocktrail::Client.new(testnet: true)
@@ -16,7 +16,7 @@ module BitcoinPayable::Adapters
       transactions = @client.address_transactions(address)
       transactions["data"].map do |tx|
         convert_transactions(
-          {"data" => tx}, 
+          {"data" => tx},
           address
         )
       end
@@ -39,21 +39,21 @@ module BitcoinPayable::Adapters
     def subscribe_to_address_push_notifications(payment)
       # Update the webhook to tell Blocktrail where to post to when a transaction is received
       @client.setup_webhook(
-        webhook_url(payment), 
-        payment.id
+        webhook_url(payment),
+        payment.id.to_s
       )
 
       # Subscribe to the address to the webhook
       @client.subscribe_address_transactions(
-        payment.id, 
-        payment.address, 
+        payment.id.to_s,
+        payment.address,
         BitcoinPayable.config.confirmations
       )
     end
 
     # Unsubscribe from the Blocktrail subscription for this address
     def unsubscribe_to_address_push_notifications(payment)
-      @client.unsubscribe_address_transactions(payment.id, payment.address)
+      @client.unsubscribe_address_transactions(payment.id.to_s, payment.address)
     rescue Blocktrail::Exceptions::ObjectNotFound => e
       puts "Blocktrail subscription for address #{address} not found: #{e}"
     end

--- a/lib/bitcoin_payable/address.rb
+++ b/lib/bitcoin_payable/address.rb
@@ -3,7 +3,7 @@ module BitcoinPayable
 
     def self.create(id)
       if BitcoinPayable.config.master_public_key
-        master = MoneyTree::Node.from_serialized_address BitcoinPayable.config.master_public_key
+        master = MoneyTree::Node.from_bip32 BitcoinPayable.config.master_public_key
         node = master.node_for_path BitcoinPayable.config.node_path + id.to_s
       else
         raise "MASTER_SEED or MASTER_PUBLIC_KEY is required"

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -25,7 +25,7 @@ module BitcoinPayable
         after do
           unsubscribe_address_push_notifications if webhooks_enabled
         end
-        transitions :from => [:pending, :paid_in_full], :to => :confirmed
+        transitions :from => [:pending, :paid_in_full, :partial_payment], :to => :confirmed
       end
 
       event :paid do

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -58,7 +58,7 @@ module BitcoinPayable
     end
 
     def calculate_btc_amount_due
-      btc_rate = BitcoinPayable::CurrencyConversion.last.btc
+      btc_rate = BitcoinPayable::CurrencyConversion.last_rate_for self.currency
       BitcoinPayable::BitcoinCalculator.exchange_price currency_amount_due, btc_rate
     end
 
@@ -71,8 +71,9 @@ module BitcoinPayable
 
     def populate_currency_and_amount_due
       self.currency ||= BitcoinPayable.config.currency
+      self.btc_conversion = CurrencyConversion.last_rate_for self.currency
       self.btc_amount_due = calculate_btc_amount_due
-      self.btc_conversion = CurrencyConversion.last.btc
+
     end
 
     def populate_address

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -74,7 +74,7 @@ module BitcoinPayable
     end
 
     def populate_address
-      self.update(address: Address.create(self.id))
+      self.update_attributes(address: Address.create(self.id))
     end
 
     def notify_status_changed

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -22,13 +22,15 @@ module BitcoinPayable
       after_all_transitions :notify_status_changed
 
       event :confirm do
+        after do
+          unsubscribe_address_push_notifications if webhooks_enabled
+        end
         transitions :from => [:pending, :paid_in_full], :to => :confirmed
       end
 
       event :paid do
         after do
           notify_payable
-          # desubscribe_tx_notifications
         end
         transitions :from => [:pending, :partial_payment], :to => :paid_in_full
       end
@@ -93,6 +95,11 @@ module BitcoinPayable
     def subscribe_to_address_push_notifications
       adapter = BitcoinPayable::Adapters::Base.fetch_adapter
       adapter.subscribe_to_address_push_notifications(self)
+    end
+
+    def unsubscribe_address_push_notifications
+      adapter = BitcoinPayable::Adapters::Base.fetch_adapter
+      adapter.unsubscribe_to_address_push_notifications(self)
     end
 
     def webhooks_enabled

--- a/lib/bitcoin_payable/bitcoin_payment.rb
+++ b/lib/bitcoin_payable/bitcoin_payment.rb
@@ -60,6 +60,11 @@ module BitcoinPayable
       BitcoinPayable::BitcoinCalculator.exchange_price currency_amount_due, btc_rate
     end
 
+    def secure?
+      return true if transactions.all?{|tx| tx.secure?}
+      return false
+    end
+
     private
 
     def populate_currency_and_amount_due

--- a/lib/bitcoin_payable/bitcoin_payment_transaction.rb
+++ b/lib/bitcoin_payable/bitcoin_payment_transaction.rb
@@ -9,5 +9,10 @@ module BitcoinPayable
       adapter = BitcoinPayable::Adapters::Base.fetch_adapter
       self.btc_conversion ||= bitcoin_payment.btc_conversion
     end
+
+    def secure?
+      return true if self.confirmations >= BitcoinPayable.config.confirmations 
+      return false
+    end
   end
 end

--- a/lib/bitcoin_payable/commands/pricing_processor.rb
+++ b/lib/bitcoin_payable/commands/pricing_processor.rb
@@ -44,7 +44,8 @@ module BitcoinPayable
       end
 
       def get_btc
-        uri = URI.parse("https://apiv2.bitcoinaverage.com/indices/local/ticker/BTC#{@currency.upcase.to_s}")
+        uri = URI.parse("https://apiv2.bitcoinaverage.com/indices/local/ticker/"\
+                        "#{BitcoinPayable.config.crypto.to_s.upcase}#{BitcoinPayable.config.currency.to_s.upcase}")
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
 

--- a/lib/bitcoin_payable/commands/pricing_processor.rb
+++ b/lib/bitcoin_payable/commands/pricing_processor.rb
@@ -1,25 +1,50 @@
 module BitcoinPayable
     class PricingProcessor
 
-      def self.perform
-        new.perform
-      end
+      class << self
+        def perform
+          new.perform
+        end
 
-      def perform
-        # => Store three previous price ranges
-        # => get_currency TODO: enable this again
-        # => Defaulting to 1.00 for now
-        rate = CurrencyConversion.create!(currency: 1.00, btc: get_btc)
+        def update_rates_for_all_pairs
+          known_currencies_in_app.each do |currency|
+              PricingProcessor.new(currency: currency).perform
+          end
+        end
 
-        # => Loop through all unpaid payments and update them with the new price
-        # => If it has been 20 mins since they have been updated
-        BitcoinPayable::BitcoinPayment.where(state: ['pending', 'partial_payment']).where("updated_at < ? OR btc_amount_due = 0", 30.minutes.ago).each do |bp|
-          bp.update_attributes!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
+        def clean_up_rates(days_old=5)
+          BitcoinPayable::CurrencyConversion.where('created_at < ?',days_old.to_i.days.ago).delete_all
+        end
+
+        private
+        def known_currencies_in_app
+          fiats_in_payments = BitcoinPayable::BitcoinPayment.pluck(:currency)
+          fiats_in_exchange_rate = BitcoinPayable::CurrencyConversion.pluck(:currency)
+          known_fiats = fiats_in_payments + fiats_in_exchange_rate
+          known_fiats.uniq
         end
       end
 
+      def initialize(args={})
+        @currency = (args[:currency] || BitcoinPayable.config.currency).downcase.to_sym
+      end
+
+      def perform
+        rate = CurrencyConversion.create!(currency: @currency, btc: get_btc)
+
+        # => Loop through all unpaid payments for a certain currency
+        # => and update them with the new price
+        # => If it has been 20 mins since they have been updated
+        BitcoinPayable::BitcoinPayment
+          .where(state: ['pending', 'partial_payment'])
+          .where(currency: @currency)
+          .where("updated_at < ? OR btc_amount_due = 0", 30.minutes.ago).each do |bp|
+            bp.update!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
+          end
+      end
+
       def get_btc
-        uri = URI.parse("https://apiv2.bitcoinaverage.com/indices/local/ticker/BTC#{BitcoinPayable.config.currency.to_s.upcase}")
+        uri = URI.parse("https://apiv2.bitcoinaverage.com/indices/local/ticker/BTC#{@currency.upcase.to_s}")
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
 
@@ -41,13 +66,13 @@ module BitcoinPayable
         rate.to_f * 100.00
       end
 
-      def get_currency
-        #uri = URI("http://rate-exchange.appspot.com/currency?from=#{BitcoinPayable.config.currency}&to=USD")
-        #rate = JSON.parse(Net::HTTP.get(uri))["rate"]
-
-        uri = URI("http://openexchangerates.org/api/latest.json?app_id=#{BitcoinPayable.config.open_exchange_key}")
-        response = JSON.parse(Net::HTTP.get(uri))
-        response["rates"][BitcoinPayable.config.currency.to_s.upcase]
-      end
+      # def get_currency
+      #   #uri = URI("http://rate-exchange.appspot.com/currency?from=#{BitcoinPayable.config.currency}&to=USD")
+      #   #rate = JSON.parse(Net::HTTP.get(uri))["rate"]
+      #
+      #   uri = URI("http://openexchangerates.org/api/latest.json?app_id=#{BitcoinPayable.config.open_exchange_key}")
+      #   response = JSON.parse(Net::HTTP.get(uri))
+      #   response["rates"][BitcoinPayable.config.currency.to_s.upcase]
+      # end
     end
 end

--- a/lib/bitcoin_payable/commands/pricing_processor.rb
+++ b/lib/bitcoin_payable/commands/pricing_processor.rb
@@ -39,7 +39,7 @@ module BitcoinPayable
           .where(state: ['pending', 'partial_payment'])
           .where(currency: @currency)
           .where("updated_at < ? OR btc_amount_due = 0", 30.minutes.ago).each do |bp|
-            bp.update_atributes!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
+            bp.update_attributes!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
           end
       end
 

--- a/lib/bitcoin_payable/commands/pricing_processor.rb
+++ b/lib/bitcoin_payable/commands/pricing_processor.rb
@@ -39,7 +39,7 @@ module BitcoinPayable
           .where(state: ['pending', 'partial_payment'])
           .where(currency: @currency)
           .where("updated_at < ? OR btc_amount_due = 0", 30.minutes.ago).each do |bp|
-            bp.update!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
+            bp.update_atributes!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
           end
       end
 

--- a/lib/bitcoin_payable/commands/pricing_processor.rb
+++ b/lib/bitcoin_payable/commands/pricing_processor.rb
@@ -14,7 +14,7 @@ module BitcoinPayable
         # => Loop through all unpaid payments and update them with the new price
         # => If it has been 20 mins since they have been updated
         BitcoinPayable::BitcoinPayment.where(state: ['pending', 'partial_payment']).where("updated_at < ? OR btc_amount_due = 0", 30.minutes.ago).each do |bp|
-          bp.update!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
+          bp.update_attributes!(btc_amount_due: bp.calculate_btc_amount_due, btc_conversion: rate.btc)
         end
       end
 

--- a/lib/bitcoin_payable/config.rb
+++ b/lib/bitcoin_payable/config.rb
@@ -22,7 +22,7 @@ module BitcoinPayable
       :allowwebhooks,
       :webhook_subdomain,
       :webhook_domain,
-      :webhook_port
+      :webhook_protocol
     )
 
     def initialize

--- a/lib/bitcoin_payable/config.rb
+++ b/lib/bitcoin_payable/config.rb
@@ -12,6 +12,7 @@ module BitcoinPayable
       :adapter_api_key,
       :testnet,
       :confirmations,
+      :crypto,
 
       # Pricing
       :open_exchange_key,
@@ -28,6 +29,7 @@ module BitcoinPayable
       @currency ||= :cad
       @confirmations ||= 6
       @rate_calculation ||= :daily_average
+      @crypto ||= :btc
     end
 
     def network

--- a/lib/bitcoin_payable/currency_conversion.rb
+++ b/lib/bitcoin_payable/currency_conversion.rb
@@ -1,5 +1,11 @@
 module BitcoinPayable
   class CurrencyConversion < ::ActiveRecord::Base
     validates :btc, presence: true
+
+    def self.last_rate_for(currency)
+      PricingProcessor.new(currency: currency).perform unless self.where(currency: currency).any?
+      self.where(currency: currency).last.btc
+    end
+
   end
 end

--- a/lib/bitcoin_payable/interactors/transaction_processor/determine_payment_status.rb
+++ b/lib/bitcoin_payable/interactors/transaction_processor/determine_payment_status.rb
@@ -4,7 +4,7 @@ module BitcoinPayable::Interactors::TransactionProcessor
 
     def call
       fiat_paid = context.bitcoin_payment.currency_amount_paid
-      
+
       if fiat_paid >= context.bitcoin_payment.price
         handle_paid_in_full unless context.bitcoin_payment.confirmed?
       elsif fiat_paid > 0
@@ -15,19 +15,19 @@ module BitcoinPayable::Interactors::TransactionProcessor
     private
 
     def handle_paid_in_full
-      if context.bitcoin_payment_transaction.confirmations >= BitcoinPayable.config.confirmations
+      if context.bitcoin_payment.secure?
         # This payment is already paid in full, we should check the confirmation count
         context.bitcoin_payment.confirm!
 
       elsif !context.bitcoin_payment.paid_in_full?
         # This payment has not been marked as paid yet, let's mark it
-        context.bitcoin_payment.paid! 
+        context.bitcoin_payment.paid!
       end
     end
 
     def handle_partial_paid
       unless context.bitcoin_payment.partial_payment?
-        context.bitcoin_payment.partially_paid! 
+        context.bitcoin_payment.partially_paid!
       end
     end
 

--- a/lib/bitcoin_payable/interactors/transaction_processor/process_transaction.rb
+++ b/lib/bitcoin_payable/interactors/transaction_processor/process_transaction.rb
@@ -4,10 +4,10 @@ module BitcoinPayable::Interactors::TransactionProcessor
 
     def call
       context.bitcoin_payment_transaction = context.bitcoin_payment.transactions.find_by_transaction_hash(context.transaction[:txHash])
-      
+
       if context.bitcoin_payment_transaction
         # We have this transaction, update it's number of confirmations
-        context.bitcoin_payment_transaction.update(confirmations: context.transaction[:confirmations])
+        context.bitcoin_payment_transaction.update_attributes(confirmations: context.transaction[:confirmations])
       else
         # We have never seen this transaction, let's create it
         context.bitcoin_payment_transaction = context.bitcoin_payment.transactions.create!(

--- a/lib/bitcoin_payable/interactors/transaction_processor/update_payment_amounts.rb
+++ b/lib/bitcoin_payable/interactors/transaction_processor/update_payment_amounts.rb
@@ -5,7 +5,7 @@ module BitcoinPayable::Interactors::TransactionProcessor
     def call
       context.bitcoin_payment.update_attributes(
         btc_amount_due: context.bitcoin_payment.calculate_btc_amount_due,
-        btc_conversion: BitcoinPayable::CurrencyConversion.last.btc
+        btc_conversion: BitcoinPayable::CurrencyConversion.last_rate_for(context.bitcoin_payment.currency)
       )
     end
 

--- a/lib/bitcoin_payable/tasks.rb
+++ b/lib/bitcoin_payable/tasks.rb
@@ -6,12 +6,18 @@ namespace :bitcoin_payable do
 
   desc "Process the prices and update the payments"
   task :process_prices => :environment do
-    BitcoinPayable::PricingProcessor.perform
+    BitcoinPayable::PricingProcessor.update_rates_for_all_pairs
   end
 
-  desc "Connect to HelloBlock.io and process payments"
+  desc "Process payments"
   task :process_payments => :environment do
     BitcoinPayable::PaymentProcessor.perform
+  end
+
+  desc "Clean old crytocurrency rates.
+  \r    You can specify the age, in days, of the rates you would like to clean."
+  task :clean_old_rates, [:days_old] => :environment do |t, args|
+    BitcoinPayable::PricingProcessor.clean_up_rates(args[:days_old])
   end
 
 end

--- a/lib/generators/bitcoin_payable/install_generator.rb
+++ b/lib/generators/bitcoin_payable/install_generator.rb
@@ -15,6 +15,7 @@ module BitcoinPayable
       migration_template 'create_currency_conversions.rb', 'db/migrate/create_currency_conversions.rb', migration_version: migration_version
       migration_template 'add_btc_conversion_to_bitcoin_payments.rb', 'db/migrate/add_btc_conversion_to_bitcoin_payments.rb', migration_version: migration_version
       migration_template 'add_confirmations_to_bitcoin_payment_transactions.rb', 'db/migrate/add_confirmations_to_bitcoin_payment_transactions.rb', migration_version: migration_version
+      migration_template 'change_colum_type_for_currency_in_currency_conversion.rb', 'db/migrate/change_colum_type_for_currency_in_currency_conversion.rb', migration_version: migration_version
     end
 
     def self.next_migration_number(dirname)

--- a/lib/generators/bitcoin_payable/templates/change_colum_type_for_currency_in_currency_conversion.rb
+++ b/lib/generators/bitcoin_payable/templates/change_colum_type_for_currency_in_currency_conversion.rb
@@ -1,0 +1,5 @@
+class ChangeColumTypeForCurrencyInCurrencyConversion < ActiveRecord::Migration<%= migration_version %>
+  def change
+    change_column :currency_conversions, :currency, :string
+  end
+end


### PR DESCRIPTION
I already merged this PR into the [master](https://github.com/maesitos/bitcoin_payable) of [my fork](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/fix/blocktrail_name_changed) and it's already running in production nicely. We can let it run there as long as you need till we consider it stable enough nonetheless it seems solid.

This PR is a merge of the following branches:

Features added:

- Support for multiple fiat currencies. 
The user can create payments using different fiat currencies as the unit of account.[release/0.8/feature/multi_fiat](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/feature/multi_fiat)

- Bitcoin Cash as an alternative cryptocurrency
[release/0.8/feature/bitcoin_cash](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/feature/bitcoin_cash)

- Deletion of unused web-hooks when a payment has been set as confirmed
[0.8/feature/remove_webhok_when_confirmed
](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/feature/remove_webhok_when_confirmed
)
- Adding SSL for the Blocktrail webhook endpoint
Sending passwords over http doesn't seem like a good idea.
[release/0.8/feature/ssl_webhook](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/feature/ssl_webhook)

Bugs fixed:

- Blocktrail bug. The API fails if we send an integer 
[release/0.8/fix/blocktrail_bug](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/fix/blocktrail_bug)

- Verify all transactions associated with a payment are secure before setting  the payment as secure 
(I already made a PR for this particular change https://github.com/Sailias/bitcoin_payable/pull/41 )
[release/0.8/fix/all_tx_must_be_secure](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/fix/all_tx_must_be_secure)

- Fix to make the gem backwards compatible with old versions of rails
[release/0.8/fix/Update-backwards_compatible](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/fix/Update-backwards_compatible)

Miscellaneous:

- Warning the user about the change of the provider of the adapter [release/0.8/fix/blocktrail_name_changed](https://github.com/maesitos/bitcoin_payable/tree/release/0.8/fix/blocktrail_name_changed)
